### PR TITLE
Fixes dead documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Documentation
 
-[https://tobii.github.io/UnitySDK/](https://tobii.github.io/UnitySDK/)
+[https://tobiitech.github.io/unity-sdk/](https://tobiitech.github.io/unity-sdk/)
 
 
 ## License
@@ -23,7 +23,7 @@ The license can also be found under `Assets\Tobii\License.pdf`.
 
 The previous Tobii Unity SDK version was called "Tobii EyeTracking SDK for Unity 5 - v2.0 (Beta)". If you have been using that version, there is a migration guide here that highlights the major and breaking changes between the 2.0 and 3.0 versions of the SDK:
 
-[https://tobii.github.io/UnitySDK/migration-guide-2.0-to-3.0](https://tobii.github.io/UnitySDK/migration-guide-2.0-to-3.0)
+[https://tobiitech.github.io/unity-sdk/migration-guide-2.0-to-3.0](https://tobiitech.github.io/unity-sdk/migration-guide-2.0-to-3.0)
 
 ## Contact ##
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -30,7 +30,7 @@ Thanks for choosing Tobii! You have invested your money and curiosity in an eye 
 
 
 ## Analytical Use
-Tobii’s consumer eye trackers are primarily intended for personal interaction use and not for analytical purposes. Any application that stores or transfers eye tracking data must have a special license from Tobii. Read more at [https://analyticaluse.tobii.com/](https://analyticaluse.tobii.com/?utm_source=tobii.github.io/UnitySDK/manual)
+Tobii’s consumer eye trackers are primarily intended for personal interaction use and not for analytical purposes. Any application that stores or transfers eye tracking data must have a special license from Tobii. Read more at [https://analyticaluse.tobii.com/](https://analyticaluse.tobii.com/?utm_source=tobiitech.github.io/unity-sdk/manual)
 
 ## Getting Started
 


### PR DESCRIPTION
There's also dead links in https://developer.tobii.com/pc-gaming/unity-sdk/

pointing to the old domain name, might need to change that as well :P